### PR TITLE
Fix token

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
         with:
-          token: ${{ secrets.AUTO_GO_FMT_PWORD }}
+          token: ${{ secrets.AUTO_GO_FMT_PWORD || secrets.GITHUB_TOKEN }}
           ref: ${{ github.ref }}
 
       - uses: actions/setup-go@v3


### PR DESCRIPTION
Dependabot doesn't seem to have access to repo secrets, so fall back to the standard token. This means that auto go-fmt won't be able to trigger workflows on dependabot PRs, but it should theoretically never have to 🤞

