### PR TITLE
Separate CodeQL from PR workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,16 +1,8 @@
 ---
 
 name: "CodeQL"
-run-name: "CodeQL started by @${{ github.actor }}"
+run-name: "CodeQL Scheduled Analysis"
 on:
-  push:
-    branches:
-      - "main"
-
-  pull_request:
-    branches:
-      - "main"
-
   schedule:
     - cron: "0 0 * * 0"
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,6 +14,25 @@ on:
 
 jobs:
 
+  analyse:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: github/codeql-action/init@v2
+        with:
+          languages: go
+          queries: +security-extended,security-and-quality
+
+      - uses: github/codeql-action/autobuild@v2
+      - uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:go"
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
To keep its PR based value, a de-matrixed version of the Go analyse job is no provided by the go.yml file. This is more semantically meaningful as it means that Go specific analysis is now provided in the same place as all the other Go workflows.

