### PR TITLE
Add test status job

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -61,7 +61,6 @@ jobs:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         go: ['^1', '1.19', '1.18', '1.16', '1.14']
 
-    name: Test with Go version ${{ matrix.go }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -71,6 +70,16 @@ jobs:
 
       - run: go build -v ./...
       - run: go test -v ./...
+
+  # https://github.com/norwd/pword/issues/61#issuecomment-1289895789
+  test-status:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1
 
   fmt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This allows the branch protection rules to only listen to a single job rather than each combination at once.