### PR TITLE
Install `gotestfmt` manually

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,12 +64,9 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - uses: GoTestTools/gotestfmt-action@v2.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
+      - run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+      - run: go build -v ./...
       - run: |
-          go build -v ./...
           go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 | gotestfmt
 
       - if: matrix.go == '^1'


### PR DESCRIPTION
This is an alternative to using the dedicated action while waiting on GoTestTools/gotestfmt-action#8 to be fixed

Signed-off-by: Yuri Norwood <106889957+norwd@users.noreply.github.com>

