### PR TITLE
Fix `test-status` workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -68,14 +68,16 @@ jobs:
           go build -v ./...
           go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 > gotest.log
 
-      - continue-on-error: true
+      - if: always()
+        continue-on-error: true
         env:
           GOTESTFMT_PACKG: github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
         run: |
           go install "$GOTESTFMT_PACKG"
           gotestfmt -input gotest.log
 
-      - continue-on-error: true
+      - if: always()
+        continue-on-error: true
         env:
           GOVERALLS_PACKG: github.com/mattn/goveralls@latest
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,14 +66,14 @@ jobs:
 
       - run: |
           go build -v ./...
-          go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 > /tmp/gotest.log
+          go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 > gotest.log
 
       - continue-on-error: true
         env:
           GOTESTFMT_PACKG: github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
         run: |
           go install "$GOTESTFMT_PACKG"
-          gotestfmt -input /tmp/gotest.log
+          gotestfmt -input gotest.log
 
       - continue-on-error: true
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,15 +64,24 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - env:
+      - run: |
+          go build -v ./...
+          go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 | tee /tmp/gotest.log
+
+      - continue-on-error: true
+        env:
           GOTESTFMT_PACKG: github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+        run: |
+          go install "$GOTESTFMT_PACKG"
+          gotestfmt -input /tmp/gotest.log
+
+      - continue-on-error: true
+        env:
           GOVERALLS_PACKG: github.com/mattn/goveralls@latest
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go build -v ./...
-          go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 | tee /tmp/gotest.log
-          go install "$GOTESTFMT_PACKG" && gotestfmt -input /tmp/gotest.log || echo "Could not format tests..."
-          go install "$GOVERALLS_PACKG" && goveralls -coverprofile "cover.out" -service github || echo "Could not upload test coverage"
+          go install "$GOVERALLS_PACKG"
+          goveralls -coverprofile "cover.out" -service github
 
   # https://github.com/norwd/pword/issues/61#issuecomment-1289895789
   test-status:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,7 +66,7 @@ jobs:
 
       - run: |
           go build -v ./...
-          go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 | tee /tmp/gotest.log
+          go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 > /tmp/gotest.log
 
       - continue-on-error: true
         env:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -65,13 +65,12 @@ jobs:
           go-version: ${{ matrix.go }}
 
       - env:
-          GOTESTCMD_FLAGS: -json -race -covermode atomic -coverprofile "cover.out" -v
           GOTESTFMT_PACKG: github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
           GOVERALLS_PACKG: github.com/mattn/goveralls@latest
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           go build -v ./...
-          go test $GOTESTCMD_FLAGS ./... 2>&1 | tee /tmp/gotest.log
+          go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 | tee /tmp/gotest.log
           go install "$GOTESTFMT_PACKG" && gotestfmt < /tmp/gotest.log
           go install "$GOVERALLS_PACKG" && goveralls -coverprofile "cover.out" -service github
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -71,8 +71,8 @@ jobs:
         run: |
           go build -v ./...
           go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 | tee /tmp/gotest.log
-          go install "$GOTESTFMT_PACKG" && gotestfmt -input /tmp/gotest.log
-          go install "$GOVERALLS_PACKG" && goveralls -coverprofile "cover.out" -service github
+          go install "$GOTESTFMT_PACKG" && gotestfmt -input /tmp/gotest.log || echo "Could not format tests..."
+          go install "$GOVERALLS_PACKG" && goveralls -coverprofile "cover.out" -service github || echo "Could not upload test coverage"
 
   # https://github.com/norwd/pword/issues/61#issuecomment-1289895789
   test-status:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,6 +80,7 @@ jobs:
   test-status:
     runs-on: ubuntu-latest
     needs: [test]
+    if: always()
     steps:
       - if: ${{ !(contains(needs.*.result, 'failure')) }}
         run: exit 0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           go build -v ./...
           go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 | tee /tmp/gotest.log
-          go install "$GOTESTFMT_PACKG" && gotestfmt < /tmp/gotest.log
+          go install "$GOTESTFMT_PACKG" && gotestfmt -input /tmp/gotest.log
           go install "$GOVERALLS_PACKG" && goveralls -coverprofile "cover.out" -service github
 
   # https://github.com/norwd/pword/issues/61#issuecomment-1289895789

--- a/internal/cmd/fake_test.go
+++ b/internal/cmd/fake_test.go
@@ -1,9 +1,0 @@
-package cmd
-
-import (
-	"testing"
-)
-
-func TestThatAlwaysFails(t *testing.T) {
-	t.Fail()
-}

--- a/internal/cmd/fake_test.go
+++ b/internal/cmd/fake_test.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"testing"
-
-	"github.com/spf13/cobra"
 )
 
 func TestThatAlwaysFails(t *testing.T) {

--- a/internal/cmd/fake_test.go
+++ b/internal/cmd/fake_test.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestThatAlwaysFails(t *testing.T) {
+	t.Fail("Argghhhh")
+}

--- a/internal/cmd/fake_test.go
+++ b/internal/cmd/fake_test.go
@@ -5,5 +5,5 @@ import (
 )
 
 func TestThatAlwaysFails(t *testing.T) {
-	t.Fail("Argghhhh")
+	t.Fail()
 }


### PR DESCRIPTION
This job was not getting run when there were test failures, which is it's whole job. Adding `if: always()` will force the job to run and not be skipped.

See: https://github.com/norwd/pword/issues/61#issuecomment-1289895789
Signed-off-by: Yuri Norwood <106889957+norwd@users.noreply.github.com>

