### PR TITLE
Consolidate go testing commands

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,26 +64,23 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-      - run: go build -v ./...
-      - run: |
-          go test -json -race -covermode atomic -coverprofile "cover.out" -v ./... 2>&1 | gotestfmt
-
-      - if: matrix.go == '^1'
-        env:
+      - env:
+          GOTESTCMD_FLAGS: -json -race -covermode atomic -coverprofile "cover.out" -v
+          GOTESTFMT_PACKG: github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+          GOVERALLS_PACKG: github.com/mattn/goveralls@latest
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          go install github.com/mattn/goveralls@latest
-          goveralls -coverprofile "cover.out" -service github
+          go build -v ./...
+          go test $GOTESTCMD_FLAGS ./... 2>&1 | tee /tmp/gotest.log
+          go install "$GOTESTFMT_PACKG" && gotestfmt < /tmp/gotest.log
+          go install "$GOVERALLS_PACKG" && goveralls -coverprofile "cover.out" -service github
 
   # https://github.com/norwd/pword/issues/61#issuecomment-1289895789
   test-status:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: exit 0
-      - if: ${{ contains(needs.*.result, 'failure') }}
+      - if: contains(needs.*.result, 'failure')
         run: exit 1
 
   fmt:


### PR DESCRIPTION
This allows a single environment definition and by utilising the `foo && bar` command chaining pattern, older versions of Go still will run `go test` without failing on later steps

Signed-off-by: Yuri Norwood <106889957+norwd@users.noreply.github.com>

<!-- LIST CHANGES HERE -->
