### PR TITLE
Add citation linter/validator

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,24 @@ on:
 
 jobs:
 
+  citations:
+    name: Lint Citations
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup
+        shell: bash
+        run: |
+          python3 -m pip install --user cffconvert
+
+      - name: Validate
+        shell: bash
+        run: |
+          cffconvert --validate
+
   markdown:
     name: Lint Markdown
     runs-on: ubuntu-latest


### PR DESCRIPTION
It may be possible to omit the checkout step altogether:

```sh
cffconvert --validate --url https://github.com/${{ github.repository }}/commit/${{ github.sha }}
```

Signed-off-by: Y. Meyer-Norwood <106889957+norwd@users.noreply.github.com>

<!-- LIST CHANGES HERE -->
