### PR TITLE
Narrow Release Concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,12 @@ permissions: read-all
 
 on:
   push:
-    branches:
-      - main
+    branches: ['main']
+    paths: ['internal/cmd/version.go']
+
+concurrency: 
+  group: release
+  cancel-in-progress: true
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
     branches: ['main']
     paths: ['internal/cmd/version.go']
 
-concurrency: 
+concurrency:
   group: release
   cancel-in-progress: true
 


### PR DESCRIPTION
This narrows down releases to *only* pushes to main that modify the version file *and* eliminates possible concurrent runs.

Since this repo only allows commits (and therefore pushes) to main in the form of merging pull requests, the only time that the release workflow is run is for a PR merge commit. And if two PRs are merged in close succession, the commit that is merged last (and completes the release workflow) will be referenced in the release.