### PR TITLE
Explicitly use norwd/fmtya@v1.1.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Format YAML Files
         if: github.ref != 'refs/heads/main'
-        uses: norwd/fmtya@v1
+        uses: norwd/fmtya@v1.1.6
         with:
 
           # github settings


### PR DESCRIPTION
This will be kept up to date using dependabot, but will explicitly use the latest version by full semver. This means that if anything breaks in `fmtya`, the new release will be caught.

Signed-off-by: Y. Meyer-Norwood <106889957+norwd@users.noreply.github.com>

<!-- LIST CHANGES HERE -->
