### PR TITLE
Determine if release is prerelease or production

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Release ${{ needs.new-version.outputs.version }}
-        run: gh release create "${{ needs.new-version.outputs.version }}" --title "${{ needs.new-version.outputs.version }} $(printf '\U0001F511\U0001F512\U0001F4BB')" --generate-notes --prerelease --target main --repo "${{ github.repository }}"
+        run: gh release create "${{ needs.new-version.outputs.version }}" --title "${{ needs.new-version.outputs.version }} $(printf '\U0001F511\U0001F512\U0001F4BB')" --generate-notes ${{ (startsWith(needs.new-version.outputs.version, 'v0') || endsWith(needs.new-version.outputs.version, '-alpha') || endsWith(needs.new-version.outputs.version, '-beta')) && '--prerelease' || '--discussion-category announcements' }} --target main --repo "${{ github.repository }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This will automatically put production releases in the announcements discussion category.

Signed-off-by: Y. Meyer-Norwood <106889957+norwd@users.noreply.github.com>

<!-- LIST CHANGES HERE -->
