### PR TITLE
Always cache/install goverals

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -171,7 +171,6 @@ jobs:
           echo '```' >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload Test Coverage
-        continue-on-error: true
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -121,23 +121,6 @@ jobs:
           # shellcheck disable=SC2016
           echo '# Run `go test` on Go${{ steps.setup-go.outputs.go-version }}-${{ runner.os }}' >> "${GITHUB_STEP_SUMMARY}"
 
-      - name: Restore goveralls from Cache
-        if: steps.cache-cover-out.outputs.cache-hit != 'true'
-        id: cache-goveralls
-        uses: actions/cache@v3
-        with:
-          path: ~/go/bin/goveralls
-          key: ${{ runner.os }}-goveralls
-
-      - name: Install goveralls
-        if: steps.cache-cover-out.outputs.cache-hit != 'true' && steps.cache-goveralls.outputs.cache-hit != 'true'
-        run: |
-          # shellcheck disable=SC2016
-          echo '## Tool Installation (`goveralls`)' >> "${GITHUB_STEP_SUMMARY}"
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
-          go install github.com/mattn/goveralls@latest 2>&1 | tee -a "${GITHUB_STEP_SUMMARY}"
-          echo '```' >> "${GITHUB_STEP_SUMMARY}"
-
       - name: Restore gotestfmt from Cache
         if: steps.cache-cover-out.outputs.cache-hit != 'true'
         id: cache-gotestfmt
@@ -169,6 +152,22 @@ jobs:
           echo '## Test Results' >> "${GITHUB_STEP_SUMMARY}"
           echo '```' >> "${GITHUB_STEP_SUMMARY}"
           go test -json -race -covermode atomic -coverprofile "cover.out" ./... 2>&1 | tee -a "${GITHUB_STEP_SUMMARY}" | gotestfmt
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Restore goveralls from Cache
+        id: cache-goveralls
+        uses: actions/cache@v3
+        with:
+          path: ~/go/bin/goveralls
+          key: ${{ runner.os }}-goveralls
+
+      - name: Install goveralls
+        if: steps.cache-goveralls.outputs.cache-hit != 'true'
+        run: |
+          # shellcheck disable=SC2016
+          echo '## Tool Installation (`goveralls`)' >> "${GITHUB_STEP_SUMMARY}"
+          echo '```' >> "${GITHUB_STEP_SUMMARY}"
+          go install github.com/mattn/goveralls@latest 2>&1 | tee -a "${GITHUB_STEP_SUMMARY}"
           echo '```' >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Upload Test Coverage


### PR DESCRIPTION
This means that the coverage results will always be uploaded, even if the source code files have not changed.

Signed-off-by: Y. Meyer-Norwood <106889957+norwd@users.noreply.github.com>

<!-- LIST CHANGES HERE -->
