### PR TITLE
Allow automerge workflow to fail silently

### DIFF
--- a/.github/workflows/enable-auto-merge.yml
+++ b/.github/workflows/enable-auto-merge.yml
@@ -21,6 +21,7 @@ jobs:
   automerge:
     name: Enable Automerge
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Enable Automerge
         run: gh -R ${{ github.repository }} pr merge ${{ github.event.number }} --auto --merge


### PR DESCRIPTION
This is to avoid false negatives as PAT errors are shown the same as broken tests.

Signed-off-by: Y. Meyer-Norwood <106889957+norwd@users.noreply.github.com>

<!-- LIST CHANGES HERE -->
